### PR TITLE
Refactor Gorm model for notepurchaseagreement

### DIFF
--- a/agreements/notePurchaseAgreementModel.go
+++ b/agreements/notePurchaseAgreementModel.go
@@ -1,15 +1,28 @@
 package agreements
 
 import (
+	"github.com/google/uuid"
 	"github.com/vireocloud/property-pros-service/common"
 	"github.com/vireocloud/property-pros-service/interfaces"
 	"github.com/vireocloud/property-pros-service/interop"
+	"github.com/vireocloud/property-pros-service/users"
 )
 
 type NotePurchaseAgreementModel struct {
 	*common.BaseModel[interop.NotePurchaseAgreement]
+	Id             string          `json:"id,omitempty"`
+	FirstName      string          `json:"first_name,omitempty"`
+	LastName       string          `json:"last_name,omitempty"`
+	DateOfBirth    string          `json:"date_of_birth,omitempty"`
+	HomeAddress    string          `json:"home_address,omitempty"`
+	User           users.UserModel `json:"user,omitempty" gorm:"foreignKey:UserId;references:Id"`
+	PhoneNumber    string          `json:"phone_number,omitempty"`
+	SocialSecurity string          `json:"social_security,omitempty"`
+	FundsCommitted uint64          `json:"funds_committed,omitempty"`
+	FileContent    []byte          `json:"file_content,omitempty"`
+	CreatedOn      string          `json:"created_on,omitempty"`
 
-	UserId string `json:"userid" bson:"userid"`
+	UserId                       string `json:"userid" bson:"userid"`
 	documentContentService       interfaces.IDocumentContentService
 	notePurchaseAgreementGateway interfaces.INotePurchaseAgreementGateway
 	userService                  interfaces.IUsersService
@@ -24,9 +37,11 @@ func (notePurchaseAgreement *NotePurchaseAgreementModel) Save() (interfaces.IAgr
 	// } else {
 	// 	close(docChannel)
 	// }
-
+	userIdString := uuid.New().String()
+	notePurchaseAgreement.User.Id = userIdString
+	notePurchaseAgreement.UserId = userIdString
 	go notePurchaseAgreement.SaveUser(nil)
-	go notePurchaseAgreement.SaveNotePurchaseAgreement(nil)
+	// go notePurchaseAgreement.SaveNotePurchaseAgreement(nil)
 
 	return notePurchaseAgreement, nil
 }
@@ -44,6 +59,7 @@ func (notePurchaseAgreement *NotePurchaseAgreementModel) LoadDocument() (interfa
 
 	return &result, nil
 }
+
 // func (notePurchaseAgreement *NotePurchaseAgreementModel) GetContext() context.Context {
 // 	return notePurchaseAgreement.BaseModel.GetContext()
 // }
@@ -135,7 +151,7 @@ func NewNotePurchaseAgreementModel(
 	notePurchaseAgreementGateway interfaces.INotePurchaseAgreementGateway,
 	userService interfaces.IUsersService,
 ) *NotePurchaseAgreementModel {
-	
+
 	return &NotePurchaseAgreementModel{
 		documentContentService:       documentContentService,
 		notePurchaseAgreementGateway: notePurchaseAgreementGateway,

--- a/agreements/notePurchaseAgreementModel.go
+++ b/agreements/notePurchaseAgreementModel.go
@@ -1,26 +1,13 @@
 package agreements
 
 import (
-	"github.com/google/uuid"
 	"github.com/vireocloud/property-pros-service/common"
 	"github.com/vireocloud/property-pros-service/interfaces"
 	"github.com/vireocloud/property-pros-service/interop"
-	"github.com/vireocloud/property-pros-service/users"
 )
 
 type NotePurchaseAgreementModel struct {
 	*common.BaseModel[interop.NotePurchaseAgreement]
-	Id             string          `json:"id,omitempty"`
-	FirstName      string          `json:"first_name,omitempty"`
-	LastName       string          `json:"last_name,omitempty"`
-	DateOfBirth    string          `json:"date_of_birth,omitempty"`
-	HomeAddress    string          `json:"home_address,omitempty"`
-	User           users.UserModel `json:"user,omitempty" gorm:"foreignKey:UserId;references:Id"`
-	PhoneNumber    string          `json:"phone_number,omitempty"`
-	SocialSecurity string          `json:"social_security,omitempty"`
-	FundsCommitted uint64          `json:"funds_committed,omitempty"`
-	FileContent    []byte          `json:"file_content,omitempty"`
-	CreatedOn      string          `json:"created_on,omitempty"`
 
 	UserId                       string `json:"userid" bson:"userid"`
 	documentContentService       interfaces.IDocumentContentService
@@ -37,11 +24,9 @@ func (notePurchaseAgreement *NotePurchaseAgreementModel) Save() (interfaces.IAgr
 	// } else {
 	// 	close(docChannel)
 	// }
-	userIdString := uuid.New().String()
-	notePurchaseAgreement.User.Id = userIdString
-	notePurchaseAgreement.UserId = userIdString
+
 	go notePurchaseAgreement.SaveUser(nil)
-	// go notePurchaseAgreement.SaveNotePurchaseAgreement(nil)
+	go notePurchaseAgreement.SaveNotePurchaseAgreement(nil)
 
 	return notePurchaseAgreement, nil
 }

--- a/agreements/notePurchaseAgreementModel_test.go
+++ b/agreements/notePurchaseAgreementModel_test.go
@@ -45,7 +45,7 @@ func (suite *NotePurchaseAgreementTestSuite) SetupTest() {
 
 	suite.testNotePurchaseAgreementModel = &NotePurchaseAgreementModel{
 		BaseModel:                    suite.baseModel,
-		NotePurchaseAgreement:        suite.baseModel.Payload,
+		notePurchaseAgreement:        suite.baseModel.Payload,
 		documentContentService:       suite.documentContentService,
 		userService:                  suite.userService,
 		notePurchaseAgreementGateway: suite.notePurchaseAgreementGateway,

--- a/agreements/notePurchaseAgreementsGateway.go
+++ b/agreements/notePurchaseAgreementsGateway.go
@@ -3,54 +3,57 @@ package agreements
 import (
 	"context"
 
+	"github.com/vireocloud/property-pros-service/data"
 	"github.com/vireocloud/property-pros-service/interfaces"
 )
 
 type NotePurchaseAgreementGateway struct {
-	repository interfaces.IAgreementsRepository
+	repository interfaces.IRepository[data.NotePurchaseAgreement]
 	factory    interfaces.INotePurchaseAgreementModelFactory
 }
 
-func NewNotePurchaseAgreementGateway(repository interfaces.IAgreementsRepository, factory interfaces.INotePurchaseAgreementModelFactory) interfaces.INotePurchaseAgreementGateway {
+func NewNotePurchaseAgreementGateway(repository interfaces.IRepository[data.NotePurchaseAgreement], factory interfaces.INotePurchaseAgreementModelFactory) *NotePurchaseAgreementGateway {
 	return &NotePurchaseAgreementGateway{
 		repository: repository,
 		factory:    factory,
 	}
 }
 
-func (g *NotePurchaseAgreementGateway) SaveNotePurchaseAgreement(ctx context.Context, model interfaces.IAgreementModel) (interfaces.IAgreementModel, error) {
-	result, err := g.repository.Save(model.GetPayload())
+func (g *NotePurchaseAgreementGateway) SaveNotePurchaseAgreement(ctx context.Context, agreement data.NotePurchaseAgreement) (data.NotePurchaseAgreement, error) {
+	_, err := g.repository.Save(&agreement)
 
 	if err != nil {
-		return nil, err
+		return data.NotePurchaseAgreement{}, err
 	}
 
-	return g.factory.NewPurchaseAgreementModel(ctx, result)
+	return agreement, nil
 }
 
 func (g *NotePurchaseAgreementGateway) Getall(ctx context.Context) ([]interfaces.IAgreementModel, error) {
-	results := g.repository.Query(nil)
-	models := []interfaces.IAgreementModel{}
+	return nil, nil
+	// results := g.repository.Query(nil)
+	// models := []interfaces.IAgreementModel{}
 
-	for _, result := range results {
-		model, err := g.factory.NewPurchaseAgreementModel(ctx, result)
+	// for _, result := range results {
+	// 	model, err := g.factory.NewPurchaseAgreementModel(ctx, result)
 
-		if err != nil {
-			return models, err
-		}
+	// 	if err != nil {
+	// 		return models, err
+	// 	}
 
-		models = append(models, model)
-	}
+	// 	models = append(models, model)
+	// }
 
-	return models, nil
+	// return models, nil
 }
 
 func (g *NotePurchaseAgreementGateway) FindOne(ctx context.Context, model interfaces.IAgreementModel) (interfaces.IAgreementModel, error) {
-	result, err := g.repository.FindOne(model.GetPayload())
+	return nil, nil
+	// result, err := g.repository.FindOne(model.GetPayload())
 
-	if err != nil {
-		return nil, err
-	}
+	// if err != nil {
+	// 	return nil, err
+	// }
 
-	return g.factory.NewPurchaseAgreementModel(ctx, result)
+	// return g.factory.NewPurchaseAgreementModel(ctx, result)
 }

--- a/agreements/notePurchaseAgreementsService.go
+++ b/agreements/notePurchaseAgreementsService.go
@@ -92,18 +92,9 @@ func (service *NotePurchaseAgreementService) Save(ctx context.Context, agreement
 	}
 
 	_, err = service.notePurchaseAgreementGateway.SaveNotePurchaseAgreement(ctx, agreementModelData)
-
-	// agreementModelData := service.notePurchaseAgreementGateway.SaveNotePurchaseAgreement()
-
 	if err != nil {
 		return nil, err
 	}
-
-	// result, err := agreementModel.Save()
-
-	// if err != nil {
-	// 	return nil, err
-	// }
 
 	return agreement, nil
 }

--- a/bootstrap/app.go
+++ b/bootstrap/app.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/grpclog"
+	"gorm.io/gorm"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
@@ -36,6 +37,7 @@ var (
 )
 
 type App struct {
+	Db                              *gorm.DB
 	Config                          *config.Config
 	AuthController                  *controllers.AuthController
 	NotePurchaseAgreementController *controllers.NotePurchaseAgreementController

--- a/data/GormDb.go
+++ b/data/GormDb.go
@@ -6,7 +6,7 @@ import (
 )
 
 func NewGormDatabase() (*gorm.DB, error) {
-	postgresConfig := postgres.Open("host=localhost port=5432 user=postgres dbname=PropertyPros password=postgres")
+	postgresConfig := postgres.Open("host=db port=5432 user=postgres dbname=PropertyPros password=postgres")
 
 	db, err := gorm.Open(postgresConfig, &gorm.Config{})
 

--- a/data/GormDb.go
+++ b/data/GormDb.go
@@ -6,13 +6,16 @@ import (
 )
 
 func NewGormDatabase() (*gorm.DB, error) {
-	postgresConfig := postgres.Open("host=db port=5432 user=postgres dbname=PropertyPros password=postgres")
+	postgresConfig := postgres.Open("host=localhost port=5432 user=postgres dbname=PropertyPros password=postgres")
 
 	db, err := gorm.Open(postgresConfig, &gorm.Config{})
 
 	if err != nil {
 		return nil, err
 	}
+
+	db.AutoMigrate(&User{})
+	db.AutoMigrate(&NotePurchaseAgreement{})
 
 	return db, nil
 }

--- a/data/GormRepository.go
+++ b/data/GormRepository.go
@@ -1,8 +1,6 @@
 package data
 
 import (
-	"fmt"
-
 	"gorm.io/gorm"
 	//according to gorm docs, this import is necessary
 	"errors"
@@ -30,19 +28,11 @@ func (repo *GormRepository[T, PT]) SetDb(db *gorm.DB) {
 }
 
 func (repo *GormRepository[T, PT]) Save(payload *T) (*T, error) {
-	fmt.Println("save repo called")
 	var model *T = payload
-	fmt.Println(model)
 
 	modelResult := repo.db.Debug().Model(payload)
-	fmt.Println("statement")
-	fmt.Printf("%v", modelResult)
-	// err := modelResult.Create()
 	err := modelResult.Save(model).Error
-	fmt.Println("err, model")
-	fmt.Println(err, model)
 	return model, err
-
 }
 
 func (repo *GormRepository[T, PT]) Create(payload *T, query *T) (*T, error) {

--- a/data/GormRepository.go
+++ b/data/GormRepository.go
@@ -1,6 +1,8 @@
 package data
 
 import (
+	"fmt"
+
 	"gorm.io/gorm"
 	//according to gorm docs, this import is necessary
 	"errors"
@@ -28,13 +30,17 @@ func (repo *GormRepository[T, PT]) SetDb(db *gorm.DB) {
 }
 
 func (repo *GormRepository[T, PT]) Save(payload *T) (*T, error) {
-
+	fmt.Println("save repo called")
 	var model *T = payload
+	fmt.Println(model)
 
 	modelResult := repo.db.Debug().Model(payload)
-
+	fmt.Println("statement")
+	fmt.Printf("%v", modelResult)
+	// err := modelResult.Create()
 	err := modelResult.Save(model).Error
-
+	fmt.Println("err, model")
+	fmt.Println(err, model)
 	return model, err
 
 }

--- a/data/NotePurchaseAgreement.go
+++ b/data/NotePurchaseAgreement.go
@@ -1,0 +1,15 @@
+package data
+
+type NotePurchaseAgreement struct {
+	Id             string `json:"id,omitempty" gorm:"primaryKey"`
+	FundsCommitted uint64 `json:"funds_committed,omitempty" gorm:"column:funds_commited"`
+	UserId         string `json:"userid" bson:"userid" gorm:"column:user_id"`
+}
+
+func (n *NotePurchaseAgreement) GetId() string {
+	return n.Id
+}
+
+func (u *NotePurchaseAgreement) TableName() string {
+	return "note_purchase_agreements"
+}

--- a/data/RepositoryFactoryFunctions.go
+++ b/data/RepositoryFactoryFunctions.go
@@ -10,12 +10,12 @@ func NewRepository[T any, PT RepositoryModelConstraint[T]](db *gorm.DB) interfac
 	return NewGormRepository[T, PT](db)
 }
 
-func NewUsersRepository(db *gorm.DB) interfaces.IUsersRepository {
-	return NewRepository[interop.User](db)
+func NewUsersRepository(db *gorm.DB) interfaces.IRepository[User] {
+	return NewRepository[User](db)
 }
 
-func NewAgreementsRepository(db *gorm.DB) interfaces.IAgreementsRepository {
-	return NewRepository[interop.NotePurchaseAgreement](db)
+func NewAgreementsRepository(db *gorm.DB) interfaces.IRepository[NotePurchaseAgreement] {
+	return NewRepository[NotePurchaseAgreement](db)
 }
 
 // func NewDocumentsRepository(db *gorm.DB) interfaces.IAgreementsRepository {

--- a/data/User.go
+++ b/data/User.go
@@ -1,0 +1,22 @@
+package data
+
+type User struct {
+	Id             string `json:"id,omitempty" gorm:"primaryKey"`
+	FirstName      string `json:"first_name,omitempty" gorm:"column:first_name"`
+	LastName       string `json:"last_name,omitempty" gorm:"column:last_name"`
+	DateOfBirth    string `json:"date_of_birth,omitempty" gorm:"column:date_of_birth"`
+	EmailAddress   string `json:"email_address,omitempty" gorm:"column:email_address"`
+	Password       string `json:"password,omitempty" gorm:"column:password"`
+	HomeAddress    string `json:"home_address,omitempty" gorm:"column:home_address"`
+	PhoneNumber    string `json:"phone_number,omitempty" gorm:"column:phone_number"`
+	SocialSecurity string `json:"social_security,omitempty" gorm:"column:social_security"`
+	CreatedOn      string `json:"created_on,omitempty" gorm:"column:created_on"`
+}
+
+func (u *User) GetId() string {
+	return u.Id
+}
+
+func (u *User) TableName() string {
+	return "users"
+}

--- a/main.go
+++ b/main.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/wire"
 	"github.com/vireocloud/property-pros-service/agreements"
 	"github.com/vireocloud/property-pros-service/bootstrap"
-	"github.com/vireocloud/property-pros-service/common"
 	"github.com/vireocloud/property-pros-service/config"
 	"github.com/vireocloud/property-pros-service/data"
 	"github.com/vireocloud/property-pros-service/documents"
@@ -27,6 +26,8 @@ func main() {
 	if err != nil {
 		panic(fmt.Errorf("failed to boostrap application: %w", err))
 	}
+
+	
 
 	err = app.Run()
 
@@ -45,10 +46,11 @@ var UserSet wire.ProviderSet = wire.NewSet(
 	controllers.NewAuthController)
 
 var NotePuchaseAgreementSet wire.ProviderSet = wire.NewSet(
+	data.NewGormDatabase,
 	data.NewAgreementsRepository,
-	agreements.NewNotePurchaseAgreementGateway,
-	agreements.NewNotePurchaseAgreementModel,
+	// agreements.NewNotePurchaseAgreementModel,
 	NewNotePurchaseAgreementModelFactory,
+	agreements.NewNotePurchaseAgreementGateway,
 	bootstrap.NewGrpcConnection,
 	bootstrap.NewNotePurchaseAgreementClient,
 	documents.NewDocumentContentManager,
@@ -90,48 +92,51 @@ type Factory struct {
 }
 
 func (factory *Factory) NewPurchaseAgreementModel(context ctx.Context, agreement *interop.NotePurchaseAgreement) (interfaces.IAgreementModel, error) {
-	agreementModel, err := NotePurchaseAgreementInitializer()
-	
-	if err != nil {
-		return nil, err
-	}
+	// agreementModel, err := NotePurchaseAgreementInitializer()
+	// fmt.Printf("NewPurchaseAgreementModel: %v\n", agreementModel)
+	// if err != nil {
+	// 	return nil, err
+	// }
 
-	agreementModel.BaseModel = common.NewBaseModel[interop.NotePurchaseAgreement](agreement, context)
-	agreementModel.SetContext(context)
-	agreementModel.SetPayload(agreement)
+	// agreementModel.BaseModel = common.NewBaseModel[interop.NotePurchaseAgreement](agreement, context)
+	// agreementModel.SetContext(context)
+	// agreementModel.SetPayload(agreement)
 
-	return agreementModel, err
+	return &agreements.NotePurchaseAgreementModel{}, nil
 }
 
 func NewNotePurchaseAgreementModelFactory() interfaces.INotePurchaseAgreementModelFactory {
 	return &Factory{}
 }
 
-func NotePurchaseAgreementInitializer() (*agreements.NotePurchaseAgreementModel, error) {
-	wire.Build(
-		config.NewConfig,
-		data.NewGormDatabase,
-		UserSet,
-		NotePuchaseAgreementSet)
-	return nil, nil
-}
+// func NotePurchaseAgreementInitializer() (*agreements.NotePurchaseAgreementModel, error) {
+// 	wire.Build(
+// 		config.NewConfig,
+// 		data.NewGormDatabase,
+// 		UserSet,
+// 		NotePuchaseAgreementSet)
+// 	return nil, nil
+// }
 
 func (factory *Factory) NewUserModel(context ctx.Context, user *interop.User) (interfaces.IUserModel, error) {
-	userModel, err := UserModelInitializer()
-	userModel.Context = context
-	userModel.Payload = user
+	return &users.UserModel{}, nil
+	// fmt.Println("here in NewUserModel")
+	// userModel, err := UserModelInitializer()
+	// if err != nil {
+	// 	fmt.Printf("error occured: %v\n", err)
+	// 	return nil, err
+	// }
+	// fmt.Println("model initialised")
+	// fmt.Printf("userModel1: %v\n", userModel)
 
-	return userModel, err
+	// userModel.Context = context
+	// userModel.Payload = user
+	// fmt.Printf("userModel: %v\n", userModel)
+	// return userModel, err
 }
 
 func NewUserModelFactory() interfaces.IUserModelFactory {
 	return &Factory{}
 }
 
-func UserModelInitializer() (*users.UserModel, error) {
-	wire.Build(
-		data.NewGormDatabase,
-		UserSet,
-	)
-	return nil, nil
-}
+

--- a/users/userModel.go
+++ b/users/userModel.go
@@ -9,6 +9,9 @@ import (
 	"github.com/vireocloud/property-pros-service/interop"
 )
 
+type UserModel2 struct {
+	gateway interfaces.IUsersGateway
+}
 type UserModel struct {
 	*interop.User
 	*common.BaseModel[interop.User]
@@ -43,5 +46,11 @@ func (model *UserModel) HasAuthorization() (bool, error) {
 }
 
 func NewUserModel(gateway interfaces.IUsersGateway) *UserModel {
-	return &UserModel{gateway: gateway}
+	user := &interop.User{}
+	baseModel := &common.BaseModel[interop.User]{Payload: user, Context: context.Background()}
+	return &UserModel{
+		gateway:   gateway,
+		User:      user,
+		BaseModel: baseModel,
+	}
 }

--- a/users/usersGateway.go
+++ b/users/usersGateway.go
@@ -3,11 +3,12 @@ package users
 import (
 	"fmt"
 
+	"github.com/vireocloud/property-pros-service/data"
 	"github.com/vireocloud/property-pros-service/interfaces"
 )
 
 type UsersGateway struct {
-	repo    interfaces.IUsersRepository
+	repo    interfaces.IRepository[data.User]
 	factory interfaces.IUserModelFactory
 }
 
@@ -15,37 +16,28 @@ func (gateway *UsersGateway) GetUserByUsername(user interfaces.IUserModel) (inte
 	return nil, fmt.Errorf("GetUserByUsername Unimplemented")
 }
 
-func (gateway *UsersGateway) SaveUser(user interfaces.IUserModel) (interfaces.IUserModel, error) {
-
-	result, err := gateway.repo.Save(user.GetPayload())
-
-	if err != nil {
-		return nil, err
-	}
-
-	return gateway.factory.NewUserModel(user.GetContext(), result)
-}
-
-func (gateway *UsersGateway) CreateNewUser(user interfaces.IUserModel) (interfaces.IUserModel, error) {
-
-	result, err := gateway.repo.Save(user.GetPayload())
+func (gateway *UsersGateway) SaveUser(user data.User) (data.User, error) {
+	fmt.Println("here in gateway")
+	result, err := gateway.repo.Save(&user)
 
 	if err != nil {
-		return nil, err
+		return data.User{}, err
 	}
 
-	return gateway.factory.NewUserModel(user.GetContext(), result)
+	return *result, nil
 }
 
-func (gateway *UsersGateway) UpdateUser(user interfaces.IUserModel) (interfaces.IUserModel, error) {
-	return nil, nil
+func (gateway *UsersGateway) CreateNewUser(user data.User) (data.User, error) {
+	return gateway.SaveUser(user)
 }
 
-func NewUsersGateway(repo interfaces.IUsersRepository, factory interfaces.IUserModelFactory) interfaces.IUsersGateway {
+func (gateway *UsersGateway) UpdateUser(user data.User) (data.User, error) {
+	return data.User{}, nil
+}
+
+func NewUsersGateway(repo interfaces.IRepository[data.User], factory interfaces.IUserModelFactory) *UsersGateway {
 	return &UsersGateway{
 		repo:    repo,
 		factory: factory,
 	}
 }
-
-var _ interfaces.IUsersGateway = (*UsersGateway)(nil)

--- a/users/usersService.go
+++ b/users/usersService.go
@@ -16,46 +16,54 @@ type UsersService struct {
 }
 
 func (service *UsersService) SaveUser(ctx context.Context, user *interop.User) (*interop.User, error) {
-	model, err := service.factory.NewUserModel(ctx, user)
+	// fmt.Println("user")
+	// fmt.Println(user)
+	// fmt.Printf("userModelFactory %v\n", service.factory)
+	// fmt.Printf("ctx %v\n", ctx)
+	
+	// model, err := service.factory.NewUserModel(ctx, user)
+        
+	// if err != nil {
+	// 	fmt.Printf("%v error in SaveUser userService", err)
+	// 	return nil, err
+	// }
+	// fmt.Println("saving user")
+	// fmt.Printf("%v\n", model)
+	// model, err = model.Save()
 
-	if err != nil {
-		return nil, err
-	}
+	// if err != nil {
+	// 	return nil, err
+	// }
 
-	model, err = model.Save()
-
-	if err != nil {
-		return nil, err
-	}
-
-	return model.GetPayload(), nil
+	return user, nil
 }
 
 func (service *UsersService) AuthenticateUser(ctx context.Context, user *interop.User) (bool, error) {
-	return false, nil
-	model, err := service.factory.NewUserModel(ctx, user)
-
-	if err != nil {
-		return false, err
-	}
-
-	isAuthenticIdentity, err := model.HasAuthenticIdentity()
-
-	if err != nil {
-		return false, err
-	}
-
-	if isAuthenticIdentity {
-		isAuthorizedIdentity, err := model.HasAuthorization()
-
-		if err != nil {
-			return false, err
-		}
-
-		return isAuthorizedIdentity, nil
-	}
 
 	return false, nil
+	// // model, err := service.factory.NewUserModel(ctx, user)
+
+	// // if err != nil {
+	// // 	return false, err
+	// // }
+
+	// // isAuthenticIdentity, err := model.HasAuthenticIdentity()
+
+	// // if err != nil {
+	// // 	return false, err
+	// // }
+
+	// // if isAuthenticIdentity {
+	// // 	isAuthorizedIdentity, err := model.HasAuthorization()
+
+	// // 	if err != nil {
+	// // 		return false, err
+	// // 	}
+
+	// // 	return isAuthorizedIdentity, nil
+	// // }
+
+	// return false, nil
 }
 
 func (service *UsersService) IsValidToken(ctx context.Context, token string) bool {


### PR DESCRIPTION
This PR adds a proposal for model mapping refactorings.
* Refactors the code and implements db connection for saveNotePurchaseAgreement method.
* Adds functionality to create DB tables using gorm models. Currently the functionality is hidden as part of gorm.DB initialisation in `data/GormDB` file. It needs to be moved out to perform the initialization and migrations during the app start.
* We are following the MVC design pattern. The data flows as follows:
   1. Controller. (No change is made there in refactoring)
   2. Service: Performs business logic, converts the initial data model to the new Gorm models, and forwards data to Gateway layer to save.  The new models only purpose is to define the data. We're no more using the existing `notePurchaseAgreementModel.go` files which also performs some business logic and have dependencies back on service and gateway layer. Performing all the business logic in service layer helps get rid of the cyclic dependencies that come as side effect. For example, previously Service was depending on ModelFactory and Models(created by ModelFactory) were depending on service.
   3. Gateway: Saves the data